### PR TITLE
Optionally reduce scope of test suite when using setup.py

### DIFF
--- a/README
+++ b/README
@@ -86,6 +86,13 @@ possible, track down the bug and include a patch that fixes it,
 provided that you are able to meet the eligibility requirements at
 http://www.pycrypto.org/submission-requirements/.
 
+It is possible to test a single sub-package or a single module only, for instance
+when you investigate why certain tests fail and don't want to run the whole
+suite each time. Use "python setup.py test --module=name", where 'name'
+is either a sub-package (Cipher, PublicKey, etc) or a module (Cipher.DES,
+PublicKey.RSA, etc).
+To further cut test coverage, pass also the option "--skip-slow-tests".
+
 To install the package under the site-packages directory of
 your Python installation, run "python setup.py install".
 

--- a/lib/Crypto/SelfTest/PublicKey/test_DSA.py
+++ b/lib/Crypto/SelfTest/PublicKey/test_DSA.py
@@ -222,7 +222,8 @@ def get_tests(config={}):
         tests += list_test_cases(DSAFastMathTest)
     except ImportError:
         pass
-    tests += list_test_cases(DSASlowMathTest)
+    if config.get('slow_tests',1): 
+        tests += list_test_cases(DSASlowMathTest)
     return tests
 
 if __name__ == '__main__':

--- a/lib/Crypto/SelfTest/PublicKey/test_RSA.py
+++ b/lib/Crypto/SelfTest/PublicKey/test_RSA.py
@@ -371,7 +371,8 @@ def get_tests(config={}):
         tests += list_test_cases(RSAFastMathTest)
     except ImportError:
         pass
-    tests += list_test_cases(RSASlowMathTest)
+    if config.get('slow_tests',1): 
+        tests += list_test_cases(RSASlowMathTest)
     return tests
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -208,14 +208,17 @@ class TestCommand(Command):
 
     description = "Run self-test"
 
+    # Long option name, short option name, description
     user_options = [
         ('skip-slow-tests', None,
-            'Skip slow tests')
+            'Skip slow tests'),
+        ('module=', 'm', 'Test a single module (e.g. Cipher, PublicKey)')
     ]
 
     def initialize_options(self):
         self.build_dir = None
         self.skip_slow_tests = None
+        self.module = None
 
     def finalize_options(self):
         self.set_undefined_options('install', ('build_lib', 'build_dir'))
@@ -228,7 +231,21 @@ class TestCommand(Command):
         try:
             sys.path.insert(0, self.build_dir)
             from Crypto import SelfTest
-            SelfTest.run(verbosity=self.verbose, stream=sys.stdout, config=self.config)
+            moduleObj = None
+            if self.module:
+                if self.module.count('.')==0:
+                    # Test a whole a sub-package
+                    full_module = "Crypto.SelfTest." + self.module
+                    module_name = self.module
+                else:
+                    # Test only a module
+                    # Assume only one dot is present
+                    comps = self.module.split('.')
+                    module_name = "test_" + comps[1]
+                    full_module = "Crypto.SelfTest." + comps[0] + "." + module_name
+                # Import sub-package or module
+                moduleObj = __import__( full_module, globals(), locals(), module_name )
+            SelfTest.run(module=moduleObj, verbosity=self.verbose, stream=sys.stdout, config=self.config)
         finally:
             # Restore sys.path
             sys.path[:] = old_path


### PR DESCRIPTION
Maybe a very tiny improvement, but I really felt the need
to re-build and run a single test case in one go.

Now I can do stuff like:

python setup.py build test -m Cipher.DES
python setup.py build test -m PublicKey

Tested with python 2.1 and 2.6 on Linux.
