### PR TITLE
fix double-decref of counter when Cipher initialisation fails

### DIFF
--- a/src/block_template.c
+++ b/src/block_template.c
@@ -212,7 +212,6 @@ ALGnew(PyObject *self, PyObject *args, PyObject *kwdict)
 	block_init(&(new->st), key, keylen);
 	if (PyErr_Occurred())
 	{
-		Py_XDECREF(counter);
 		Py_DECREF(new);
 		return NULL;
 	}


### PR DESCRIPTION
A simple fix to avoid double-decrefing the "counter" attribute of cipher objects.  Since this is done in ALGdealloc, there's no need to do it explicitly when ALGnew exits with error.

This was causing strange and very hard-to-reproduce segfaults for me.
