### PR TITLE
Add trove classifiers to indicate Python 2 and 3 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -478,6 +478,8 @@ if hasattr(core, 'setup_keywords'):
           'Operating System :: Microsoft :: Windows',
           'Operating System :: MacOS :: MacOS X',
           'Topic :: Security :: Cryptography',
+          'Programming Language :: Python :: 2',
+          'Programming Language :: Python :: 3',
           ]
     if 'download_url' in core.setup_keywords:
         kw['download_url'] = ('http://www.pycrypto.org/files/'


### PR DESCRIPTION
These classifiers allow automated tools like http://python3wos.appspot.com/ to recognise Python 3 compatible packages. Since I see Pycrypto has been made to work on Python 3, it makes sense to indicate that.
