### PR TITLE
Update docstring. IVs are no longer optional

### DIFF
--- a/lib/Crypto/Cipher/AES.py
+++ b/lib/Crypto/Cipher/AES.py
@@ -79,8 +79,7 @@ def new(key, *args, **kwargs):
         actually the *encrypted* IV which was prefixed to the ciphertext).
         It is mandatory.
        
-        For all other modes, it must be `block_size` bytes longs. It is optional and
-        when not present it will be given a default value of all zeroes.
+        For all other modes, it must be `block_size` bytes longs.
       counter : callable
         (*Only* `MODE_CTR`). A stateful function that returns the next
         *counter block*, which is a byte string of `block_size` bytes.

--- a/lib/Crypto/Cipher/ARC2.py
+++ b/lib/Crypto/Cipher/ARC2.py
@@ -91,8 +91,7 @@ def new(key, *args, **kwargs):
         actually the *encrypted* IV which was prefixed to the ciphertext).
         It is mandatory.
        
-        For all other modes, it must be `block_size` bytes longs. It is optional and
-        when not present it will be given a default value of all zeroes.
+        For all other modes, it must be `block_size` bytes longs.
       counter : callable
         (*Only* `MODE_CTR`). A stateful function that returns the next
         *counter block*, which is a byte string of `block_size` bytes.

--- a/lib/Crypto/Cipher/Blowfish.py
+++ b/lib/Crypto/Cipher/Blowfish.py
@@ -85,8 +85,7 @@ def new(key, *args, **kwargs):
         actually the *encrypted* IV which was prefixed to the ciphertext).
         It is mandatory.
        
-        For all other modes, it must be `block_size` bytes longs. It is optional and
-        when not present it will be given a default value of all zeroes.
+        For all other modes, it must be `block_size` bytes longs.
       counter : callable
         (*Only* `MODE_CTR`). A stateful function that returns the next
         *counter block*, which is a byte string of `block_size` bytes.

--- a/lib/Crypto/Cipher/CAST.py
+++ b/lib/Crypto/Cipher/CAST.py
@@ -88,8 +88,7 @@ def new(key, *args, **kwargs):
         actually the *encrypted* IV which was prefixed to the ciphertext).
         It is mandatory.
        
-        For all other modes, it must be `block_size` bytes longs. It is optional and
-        when not present it will be given a default value of all zeroes.
+        For all other modes, it must be `block_size` bytes longs.
       counter : callable
         (*Only* `MODE_CTR`). A stateful function that returns the next
         *counter block*, which is a byte string of `block_size` bytes.

--- a/lib/Crypto/Cipher/DES.py
+++ b/lib/Crypto/Cipher/DES.py
@@ -83,8 +83,7 @@ def new(key, *args, **kwargs):
         actually the *encrypted* IV which was prefixed to the ciphertext).
         It is mandatory.
        
-        For all other modes, it must be `block_size` bytes longs. It is optional and
-        when not present it will be given a default value of all zeroes.
+        For all other modes, it must be `block_size` bytes longs.
       counter : callable
         (*Only* `MODE_CTR`). A stateful function that returns the next
         *counter block*, which is a byte string of `block_size` bytes.

--- a/lib/Crypto/Cipher/DES3.py
+++ b/lib/Crypto/Cipher/DES3.py
@@ -96,8 +96,7 @@ def new(key, *args, **kwargs):
         actually the *encrypted* IV which was prefixed to the ciphertext).
         It is mandatory.
        
-        For all other modes, it must be `block_size` bytes longs. It is optional and
-        when not present it will be given a default value of all zeroes.
+        For all other modes, it must be `block_size` bytes longs.
       counter : callable
         (*Only* `MODE_CTR`). A stateful function that returns the next
         *counter block*, which is a byte string of `block_size` bytes.


### PR DESCRIPTION
Seeing as IVs are required. Let's say so in the documentation.
