### PR TITLE
Except shadows builtin IndexError.

### DIFF
--- a/lib/Crypto/PublicKey/RSA.py
+++ b/lib/Crypto/PublicKey/RSA.py
@@ -582,7 +582,7 @@ class RSAImplementation(object):
                     if privateKey.isType('OCTET STRING'):
                         return self._importKeyDER(privateKey.payload)
 
-        except ValueError, IndexError:
+        except (ValueError, IndexError):
             pass
 
         raise ValueError("RSA key format is not supported")


### PR DESCRIPTION
Constructs like

 try:
   ...
 except ValueError, IndexError:
   ...

don't work as expected. This only catches a ValueError and replaces the builtin
IndexError with the catched ValueError object. See [1] for details.

[1] http://docs.python.org/whatsnew/2.6.html#pep-3110-exception-handling-changes
