### PR TITLE
Store result of rabinMillerTest in an int.

### DIFF
--- a/src/_fastmath.c
+++ b/src/_fastmath.c
@@ -1449,13 +1449,13 @@ cleanup:
 static PyObject *
 getStrongPrime (PyObject *self, PyObject *args, PyObject *kwargs)
 {
-	unsigned long int i, j, result, bits, x, e=0;
+	unsigned long int i, j, bits, x, e=0;
 	mpz_t p[2], y[2], R, X;
 	mpz_t tmp[2], lower_bound, upper_bound, range, increment;
 	mpf_t tmp_bound;
 	char *field;
 	double false_positive_prob;
-	int rabin_miller_rounds, is_possible_prime, error = 0;
+	int rabin_miller_rounds, is_possible_prime, error = 0, result;
 	PyObject *prime, *randfunc=NULL;
 	static char *kwlist[] = {"N", "e", "false_positive_prob", "randfunc", NULL};
 	unsigned long int base_size = SIEVE_BASE_SIZE;


### PR DESCRIPTION
rabinMillerTest returns an int but getStrongPrime stores the result in an
unsigned long int which makes the tests in line 1545 and 1621 useless.

This issue has been found with the help of clang.
