### PR TITLE
allow building on OpenBSD

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -373,7 +373,7 @@ kw = {'name':"pycrypto",
       'ext_modules': plat_ext + [
             # _fastmath (uses GNU mp library)
             Extension("Crypto.PublicKey._fastmath",
-                      include_dirs=['src/','/usr/include/'],
+                      include_dirs=['src/','/usr/include/','/usr/local/include/'],
                       libraries=['gmp'],
                       sources=["src/_fastmath.c"]),
 


### PR DESCRIPTION
OpenBSD (and probably others) installs packages below /usr/local which means includes for packages that are not part of the base system end up in /usr/local/include

pycrypto relies on the gmp library and won't build on OpenBSD because /usr/local/include is not part of the include path used by setup.py

care to add it ? :-)

Thanks for your work,  pycrypto <3 <3
