### PR TITLE
Fix installation chmod issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -274,8 +274,7 @@ class PCTBuildConfigure(Command):
 
     def run(self):
         if not os.path.exists("config.status"):
-            if os.system("chmod 0755 configure") != 0:
-                raise RuntimeError("chmod error")
+            os.chmod("configure", 755)
             cmd = "sh configure"    # we use "sh" here so that it'll work on mingw32 with standard python.org binaries
             if self.verbose < 1:
                 cmd += " -q"


### PR DESCRIPTION
If installation is performed without the executable for chmod being on the PATH (not outside
of the realms of possibility), the current installation fails. To correct, use the Python os.chmod function.

In my case this happens because the installs are done as an unprivileged user which doesn't have /bin on its `PATH`.
