### PR TITLE
Re-open the OSRNG object to get a new file descriptor

### DIFF
--- a/lib/Crypto/Random/_UserFriendlyRNG.py
+++ b/lib/Crypto/Random/_UserFriendlyRNG.py
@@ -56,6 +56,12 @@ class _EntropyCollector(object):
         self._clock_es = _EntropySource(accumulator, 253)
 
     def reinit(self):
+        # re-open the OSRNG as its file descriptor might have been closed after forking
+        try:
+            self._osrng.close()
+        except IOError:
+            pass
+        self._osrng = OSRNG.new()
         # Add 256 bits to each of the 32 pools, twice.  (For a total of 16384
         # bits collected from the operating system.)
         for i in range(2):


### PR DESCRIPTION
The previous file descriptor in the OSRNG object might have been closed
after forking (e.g. by using the script from
http://code.activestate.com/recipes/278731-creating-a-daemon-the-python-way/
which explicitly closes all open file descriptors after forking).

In detail:
we are using the above mentioned script here at work to implement web services which fork themselves and run as daemons. The daemonize script explicitly closes all open file descriptors in the child process where we use Paramiko for SSH communication. 
Once Paramiko is imported, it calls Crypto.Random.new() on module-level and this causes an instantiation of DevURandomRNG(on posix systems at least). In our cases this happens before we are forking. After we've forked, the previously opened file descriptor in the DevURandomRNG object isn't available anymore. Thus this change to automatically re-open the file on reinit().

I realise that part of this problem is Paramiko which calls Crypto.Random.new() on module-level. I'll report this as well. Though I think re-opening the file descriptor on reinit() is a good thing anyways.
