### PR TITLE
stream handling in SelfTest

### DIFF
--- a/lib/Crypto/SelfTest/__init__.py
+++ b/lib/Crypto/SelfTest/__init__.py
@@ -66,6 +66,8 @@ def run(module=None, verbosity=0, stream=None, tests=None, config=None, **kwargs
             raise ValueError("'module' and 'tests' arguments are mutually exclusive")
     if stream is None:
         kwargs['stream'] = StringIO()
+    else:
+        kwargs['stream'] = stream
     runner = unittest.TextTestRunner(verbosity=verbosity, **kwargs)
     result = runner.run(suite)
     if not result.wasSuccessful():


### PR DESCRIPTION
The two commits change the stream handling in the following way: if stream is None and a test fails, write the correct stream to sys.stderr and if stream is not None, pass it to TestTextRunner.
