### PR TITLE
HMAC can securely validate if a MAC is correct.

### DIFF
--- a/lib/Crypto/Hash/HMAC.py
+++ b/lib/Crypto/Hash/HMAC.py
@@ -54,7 +54,7 @@ This is an example showing how to *create* a MAC:
 
 This is an example showing how to *check* a MAC:
 
-    >>> from Crypto.Hash import HMAC
+    >>> from Crypto.Hash import HMAC, MacMismatchError
     >>>
     >>> # We have received a message 'msg' together
     >>> # with its MAC 'mac'
@@ -65,7 +65,7 @@ This is an example showing how to *check* a MAC:
     >>> try:
     >>>   h.verify(mac)
     >>>   print "The message '%s' is authentic" % msg
-    >>> except ValueError:
+    >>> except MacMismatchError:
     >>>   print "The message or the key is wrong"
 
 .. _RFC2104: http://www.ietf.org/rfc/rfc2104.txt
@@ -83,6 +83,7 @@ from binascii import unhexlify
 
 from Crypto.Util.strxor import strxor_c
 from Crypto.Util.py3compat import *
+from Crypto.Hash import MacMismatchError
 
 #: The size of the authentication tag produced by the MAC.
 #: It matches the digest size on the underlying
@@ -202,7 +203,7 @@ class HMAC:
         :Parameters:
           mac_tag : byte string
             The expected MAC of the message.
-        :Raises ValueError:
+        :Raises MacMismatchError:
             if the MAC does not match. It means that the message
             has been tampered with or that the MAC key is incorrect.
         """
@@ -213,7 +214,7 @@ class HMAC:
         for x,y in zip(mac, mac_tag):
             res |= bord(x) ^ bord(y)
         if res or len(mac_tag)!=self.digest_size:
-            raise ValueError("MAC check failed")
+            raise MacMismatchError("MAC check failed")
 
     def hexdigest(self):
         """Return the **printable** MAC of the message that has been
@@ -233,7 +234,7 @@ class HMAC:
         :Parameters:
           hex_mac_tag : string
             The expected MAC of the message, as a hexadecimal string.
-        :Raises ValueError:
+        :Raises MacMismatchError:
             if the MAC does not match. It means that the message
             has been tampered with or that the MAC key is incorrect.
         """

--- a/lib/Crypto/Hash/__init__.py
+++ b/lib/Crypto/Hash/__init__.py
@@ -50,13 +50,17 @@ The hashing modules here all support the interface described in `PEP
 """
 
 __all__ = ['HMAC', 'MD2', 'MD4', 'MD5', 'RIPEMD160', 'SHA1',
-           'SHA224', 'SHA256', 'SHA384', 'SHA512']
+           'SHA224', 'SHA256', 'SHA384', 'SHA512', 'MacMismatchError' ]
 __revision__ = "$Id$"
 
 import sys
 if sys.version_info[0] == 2 and sys.version_info[1] == 1:
     from Crypto.Util.py21compat import *
 from Crypto.Util.py3compat import *
+
+class MacMismatchError(Exception):
+    """Exception raised when MAC verification fails."""
+    pass
 
 def new(algo, *args):
     """Initialize a new hash object.

--- a/lib/Crypto/SelfTest/Hash/common.py
+++ b/lib/Crypto/SelfTest/Hash/common.py
@@ -34,6 +34,8 @@ from Crypto.Util.py3compat import *
 if sys.version_info[0] == 2 and sys.version_info[1] == 1:
     from Crypto.Util.py21compat import *
 
+from Crypto.Hash import MacMismatchError
+
 # For compatibility with Python 2.1 and Python 2.2
 if sys.hexversion < 0x02030000:
     # Python 2.1 doesn't have a dict() function
@@ -195,8 +197,8 @@ class MACSelfTest(unittest.TestCase):
 
             # Verify that incorrect MAC does raise ValueError exception
             wrong_mac = strxor_c(out1_bin, 255)
-            self.assertRaises(ValueError, h.verify, wrong_mac)
-            self.assertRaises(ValueError, h.hexverify, "4556")
+            self.assertRaises(MacMismatchError, h.verify, wrong_mac)
+            self.assertRaises(MacMismatchError, h.hexverify, "4556")
 
             h = self.hashmod.new(key, data, hashmod)
 


### PR DESCRIPTION
In the current implementation, it is left up to the caller
to assess if the locally computed MAC matches the MAC associated
to the received message.

However, the most natural way to do that (use == operator)
is also deepy unsecure, see here:

http://seb.dbzteam.org/crypto/python-oauth-timing-hmac.pdf

With this patch, the HMAC.digest() method can optionally accept
the given MAC and perform the check on behalf of the caller.
The method will use constant-time code (still dependent on the length
of the MAC, but not on the actual content).
