### PR TITLE
Add support for the "new-style" Py_buffer api found in Python >= 2.6

### DIFF
--- a/src/pycrypto_compat.h
+++ b/src/pycrypto_compat.h
@@ -73,5 +73,9 @@ typedef int Py_ssize_t;
 typedef void PyMODINIT_FUNC;
 #endif
 
+#if PY_VERSION_HEX >= 0x02060000
+#define HAVE_NEW_BUFFER_API
+#endif
+
 #endif /* PYCRYPTO_COMPAT_H */
 /* vim:set ts=4 sw=4 sts=4 expandtab: */


### PR DESCRIPTION
This is needed to be able to encrypt/decrypt memoryview() objects
introduced in Python 2.7. This is extra important with Python 3 where
the buffer() object has been removed.

This also fixes a potential memory leak in stream_template.py:ALGnew().
