### PR TITLE
Fix: AttributeError: 'module' object has no attribute 'HAVE_DECL_MPZ_POW...

### DIFF
--- a/lib/Crypto/Util/number.py
+++ b/lib/Crypto/Util/number.py
@@ -53,7 +53,7 @@ except ImportError:
     _fastmath = None
 
 # You need libgmp v5 or later to get mpz_powm_sec.  Warn if it's not available.
-if _fastmath is not None and not _fastmath.HAVE_DECL_MPZ_POWM_SEC:
+if _fastmath is not None and not (hasattr(_fastmath, "HAVE_DECL_MPZ_POWM_SEC") and _fastmath.HAVE_DECL_MPZ_POWM_SEC):
     _warn("Not using mpz_powm_sec.  You should rebuild using libgmp >= 5 to avoid timing attack vulnerability.", PowmInsecureWarning)
 
 # New functions


### PR DESCRIPTION
...M_SEC'

Fixing run time error caused by invalid attribute reference on object:

from Crypto import Random
  File "/usr/lib64/python2.6/site-packages/Crypto/Random/**init**.py", line 29, in <module>
    from Crypto.Random import _UserFriendlyRNG
  File "/usr/lib64/python2.6/site-packages/Crypto/Random/_UserFriendlyRNG.py", line 38, in <module>
    from Crypto.Random.Fortuna import FortunaAccumulator
  File "/usr/lib64/python2.6/site-packages/Crypto/Random/Fortuna/FortunaAccumulator.py", line 39, in <module>
    import FortunaGenerator
  File "/usr/lib64/python2.6/site-packages/Crypto/Random/Fortuna/FortunaGenerator.py", line 34, in <module>
    from Crypto.Util.number import ceil_shift, exact_log2, exact_div
  File "/usr/lib64/python2.6/site-packages/Crypto/Util/number.py", line 56, in <module>
    if _fastmath is not None and not getattr(_fastmath, "HAVE_DECL_MPZ_POWM_SEC"):
AttributeError: 'module' object has no attribute 'HAVE_DECL_MPZ_POWM_SEC'
