### PR TITLE
Travis CI Support (Free Test Server)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python:
+  - "2.5"
+  - "2.6"
+  - "2.7"
+  - "3.2"
+  - "3.3"
+# PyCrypto does not support PyPy yet.
+# See https://github.com/dlitz/pycrypto/pull/59
+#  - "pypy"
+script: python setup.py test


### PR DESCRIPTION
Intro copied from my [SJCL pull request](https://github.com/bitwiseshiftleft/sjcl/pull/109):

> I just discovered that [Travis CI](https://travis-ci.org/) is free for open-source projects, and very easy to use.
> 
> All that's necessary is:
> - Add a `.travis.yml` file to the repo.
> - Somebody with admin privileges for the project signs up for https://travis-ci.org/ (using GitHub) and enables it for the project.
> 
> Then any commit or pull request associated with the repository triggers Travis CI to run unit tests immediately, and the results show up with nice little indicators on GitHub (as well as being visible on Travis CI and emailed to contributors).

The config file is straightforward for PyCrypto.
The main issue is that Travis only supports Python version 2.5, 2.6, 2.7, 3.2, 3.3. (PyPy is also supported, but [the building stage fails](https://travis-ci.org/lgarron/pycrypto/jobs/12473764) even with the [current PyPy pull request](https://github.com/dlitz/pycrypto/pull/59).)

It would be possible to provide support for the other Python versions (2.1, 2.2, 2.3, 2.4, 3.0, 3.1) by installing custom Python builds during testing; I'm not sure how much work that would be, and/or if there's a good way to add any "extra" test versions to the supported ones.
(A less semantically awesome approach would be to install custom versions of python and run them all in a "single" test.)

Here's Travis CI running successfully on my fork: https://travis-ci.org/lgarron/pycrypto/builds
Successful build: https://travis-ci.org/lgarron/pycrypto/builds/12475769
Failed build: https://travis-ci.org/lgarron/pycrypto/builds/12475958
