### PR TITLE
Do not run multiprocessing test if multiprocessing.synchronize is not working

### DIFF
--- a/lib/Crypto/SelfTest/Random/test__UserFriendlyRNG.py
+++ b/lib/Crypto/SelfTest/Random/test__UserFriendlyRNG.py
@@ -39,6 +39,11 @@ from Crypto.Util.py3compat import *
 
 try:
     import multiprocessing
+    # multiprocessing.Pool uses classes from multiprocessing.synchronize, so we
+    # need to check if multiprocessing.semaphore will work. Otherwise creating a
+    # multiprocessing.Pool instance will fail with an ImportError. See Python
+    # bug #3770 for details.
+    import multiprocessing.synchronize
 except ImportError:
     multiprocessing = None
 


### PR DESCRIPTION
On platforms that do not have a working sem_open implementation, importing
multiprocessing.synchronize will fail with an ImportError. While creating a
multiprocessing.Pool instance, multiprocessing.synchronize will be imported and
might throw an ImportError.

Signed-off-by: Sebastian Ramacher <sebastian+dev@ramacher.at>
