### PR TITLE
Add support for tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ src/stamp-h1
 
 # Backup files
 *~
+
+# Tox
+.tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py25, py26, py27, py32, py33, py34, pypy
+
+[testenv]
+commands = {envpython} setup.py test


### PR DESCRIPTION
This adds support for [Tox](http://tox.testrun.org/), which lets you test locally with different Python versions.

The ability to test locally without committing or pushing is super nice and helps to ensure compatibility across various Python versions.
