### PR TITLE
Use different method for getting ext_suffix

### DIFF
--- a/lib/Crypto/SelfTest/PublicKey/test_DSA.py
+++ b/lib/Crypto/SelfTest/PublicKey/test_DSA.py
@@ -225,16 +225,8 @@ def get_tests(config={}):
         from Crypto.PublicKey import _fastmath
         tests += list_test_cases(DSAFastMathTest)
     except ImportError:
-        from distutils.sysconfig import get_config_var
-        import inspect
-        ext_suffix = get_config_var("EXT_SUFFIX") or get_config_var("SO")
-        _fm_path = os.path.normpath(os.path.dirname(os.path.abspath(
-            inspect.getfile(inspect.currentframe())))
-            +"/../../PublicKey/_fastmath"+ext_suffix)
-        if os.path.exists(_fm_path):
-            raise ImportError("While the _fastmath module exists, importing "+
-                "it failed. This may point to the gmp or mpir shared library "+
-                "not being in the path. _fastmath was found at "+_fm_path)
+        from Crypto.SelfTest.st_common import handle_fastmath_import_error
+        handle_fastmath_import_error()
     tests += list_test_cases(DSASlowMathTest)
     return tests
 

--- a/lib/Crypto/SelfTest/PublicKey/test_RSA.py
+++ b/lib/Crypto/SelfTest/PublicKey/test_RSA.py
@@ -461,16 +461,8 @@ def get_tests(config={}):
         from Crypto.PublicKey import _fastmath
         tests += list_test_cases(RSAFastMathTest)
     except ImportError:
-        from distutils.sysconfig import get_config_var
-        import inspect
-        ext_suffix = get_config_var("EXT_SUFFIX") or get_config_var("SO")
-        _fm_path = os.path.normpath(os.path.dirname(os.path.abspath(
-            inspect.getfile(inspect.currentframe())))
-            +"/../../PublicKey/_fastmath"+ext_suffix)
-        if os.path.exists(_fm_path):
-            raise ImportError("While the _fastmath module exists, importing "+
-                "it failed. This may point to the gmp or mpir shared library "+
-                "not being in the path. _fastmath was found at "+_fm_path)
+        from Crypto.SelfTest.st_common import handle_fastmath_import_error
+        handle_fastmath_import_error()
     if config.get('slow_tests',1):
         tests += list_test_cases(RSASlowMathTest)
     return tests

--- a/lib/Crypto/SelfTest/Util/test_number.py
+++ b/lib/Crypto/SelfTest/Util/test_number.py
@@ -325,16 +325,8 @@ def get_tests(config={}):
         from Crypto.PublicKey import _fastmath
         tests += list_test_cases(FastmathTests)
     except ImportError:
-        from distutils.sysconfig import get_config_var
-        import inspect, os.path
-        ext_suffix = get_config_var("EXT_SUFFIX") or get_config_var("SO")
-        _fm_path = os.path.normpath(os.path.dirname(os.path.abspath(
-            inspect.getfile(inspect.currentframe())))
-            +"/../../PublicKey/_fastmath"+ext_suffix)
-        if os.path.exists(_fm_path):
-            raise ImportError("While the _fastmath module exists, importing "+
-                "it failed. This may point to the gmp or mpir shared library "+
-                "not being in the path. _fastmath was found at "+_fm_path)
+        from Crypto.SelfTest.st_common import handle_fastmath_import_error
+        handle_fastmath_import_error()
     return tests
 
 if __name__ == '__main__':

--- a/lib/Crypto/SelfTest/st_common.py
+++ b/lib/Crypto/SelfTest/st_common.py
@@ -59,4 +59,16 @@ def b2a_hex(s):
     # For completeness
     return binascii.b2a_hex(s)
 
+def handle_fastmath_import_error():
+    from distutils.sysconfig import get_config_var
+    import inspect, os.path
+    ext_suffix = get_config_var("EXT_SUFFIX") or get_config_var("SO")
+    _fm_path = os.path.normpath(os.path.dirname(os.path.abspath(
+        inspect.getfile(inspect.currentframe())))
+        +"/../../PublicKey/_fastmath"+ext_suffix)
+    if os.path.exists(_fm_path):
+        raise ImportError("While the _fastmath module exists, importing "+
+            "it failed. This may point to the gmp or mpir shared library "+
+            "not being in the path. _fastmath was found at "+_fm_path)
+
 # vim:set ts=4 sw=4 sts=4 expandtab:


### PR DESCRIPTION
``` python
ext_suffix = get_config_var("EXT_SUFFIX") or get_config_var("SO")
```

because `get_config_var("SO")` returns None in Python 3.4.0a4 because the `"SO"` variable is deprecated and `"EXT_SUFFIX"` is the new way to get this information (see: http://bugs.python.org/issue19555)

This fixes `TypeError: Can't convert 'NoneType' object to str implicitly` errors when running the tests on Python 3.4.0a4.

Note that the fact that I had to make this change in 3 places suggests that it would be nice to refactor so that this code lives in one place, which I did in 84bb4aa.

Testing -- using the `tox.ini` in #64, I get:

```
vagrant@ubuntu:~/dev/git-repos/pycrypto$ tox -e py25,py26,py27,py32,py33,py34
...
  py25: commands succeeded
  py26: commands succeeded
  py27: commands succeeded
  py32: commands succeeded
  py33: commands succeeded
  py34: commands succeeded
  congratulations :)
```
