### PR TITLE
Sign the hash in the the PKCS1_PSS doctest, not the key

### DIFF
--- a/lib/Crypto/Signature/PKCS1_PSS.py
+++ b/lib/Crypto/Signature/PKCS1_PSS.py
@@ -39,7 +39,7 @@ this:
     >>> h = SHA1.new()
     >>> h.update(message)
     >>> signer = PKCS1_PSS.new(key)
-    >>> signature = signer.sign(key)
+    >>> signature = signer.sign(h)
 
 At the receiver side, verification can be done like using the public part of
 the RSA key:


### PR DESCRIPTION
As it stood before this commit, the hash was never used in the signing 
process.  It looks like the bug was introduced by e053629 (Restructure both
PKCS#1 signature schemes as objects, 2011-10-16), which changed:

```
-    >>> signature = PKCS1_PSS.sign(h, key)
+    >>> signer = PKCS1_PSS.new(key)
+    >>> signature = PKCS1_PSS.sign(key)
```
