### PR TITLE
PBKDF2() does not correctly handle a salt that is string in Python 3

### DIFF
--- a/lib/Crypto/Protocol/KDF.py
+++ b/lib/Crypto/Protocol/KDF.py
@@ -113,6 +113,7 @@ def PBKDF2(password, salt, dkLen=16, count=1000, prf=None):
         If you wanted multiple keys, just break up this string into segments of the desired length.
 """
     password = tobytes(password)
+    salt = tobytes(salt)
     if prf is None:
         prf = lambda p,s: HMAC.new(p,s,SHA1).digest()
     key = b('')


### PR DESCRIPTION
Greetings,

In Python 3, the PBKDF2 function does not correctly handle a salt that is passed to it as a string, as the PyDoc suggests it should. I checked the test cases for the KDF functions and they're only passing byte arrays and not strings. I corrected the problem by handling the salt like the password and passing the salt through tobytes() before doing anything.

```
>>> from Crypto.Protocol.KDF import PBKDF2
>>> PBKDF2('PasswordPasswordPassword', 'SaltSaltSalt')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.3/site-packages/Crypto/Protocol/KDF.py", line 116, in PBKDF2
    U = previousU = prf(password,salt+struct.pack(">I", i))
TypeError: Can't convert 'bytes' object to str implicitly
```

Thanks!
