### PR TITLE
hash/CMAC: add XCBCMAC class

### DIFF
--- a/lib/Crypto/Hash/XCBCMAC.py
+++ b/lib/Crypto/Hash/XCBCMAC.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+#
+# Hash/XCBCMAC.py - Implements the XCBC-MAC algorithm
+#
+# ===================================================================
+# The contents of this file are dedicated to the public domain.  To
+# the extent that dedication to the public domain is not available,
+# everyone is granted a worldwide, perpetual, royalty-free,
+# non-exclusive license to exercise all rights associated with the
+# contents of this file for any purpose whatsoever.
+# No rights are reserved.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# ===================================================================
+
+__all__ = ['new', 'digest_size', 'XCBCMAC' ]
+
+import sys
+if sys.version_info[0] == 2 and sys.version_info[1] == 1:
+    from Crypto.Util.py21compat import *
+from Crypto.Util.py3compat import *
+
+from Crypto.Hash.CMAC import _SmoothMAC, CMAC
+
+#: The size of the authentication tag produced by the MAC.
+digest_size = None
+
+class XCBCMAC(CMAC):
+    """Older version of the CMAC algorithm that uses a different way to
+    compute sub-keys.
+
+    Reference from RFC 3566 - Section 4 (http://tools.ietf.org/html/rfc3566)
+
+        Derive 3 128-bit keys (K1, K2 and K3) from the 128-bit secret
+        key K, as follows:
+        K1 = 0x01010101010101010101010101010101 encrypted with Key K
+        K2 = 0x02020202020202020202020202020202 encrypted with Key K
+        K3 = 0x03030303030303030303030303030303 encrypted with Key K
+
+    This was checked with the test vectors provided in RFC 3566 - Section 4.6
+    """
+    def __init__(self, key, msg=None, ciphermod=None):
+        CMAC.__init__(self, key, msg=msg, ciphermod=ciphermod)
+
+        # MODE_ECB is to avoid propagation between blocks for the computation
+        # of the sub-keys
+        key_cipher = ciphermod.new(key, ciphermod.MODE_ECB)
+
+        self._k0 = key_cipher.encrypt(bchr(1) * ciphermod.block_size)
+        self._k1 = key_cipher.encrypt(bchr(2) * ciphermod.block_size)
+        self._k2 = key_cipher.encrypt(bchr(3) * ciphermod.block_size)
+
+        self._mac = ciphermod.new(self._k0, ciphermod.MODE_CBC, self._IV)
+
+    def copy(self):
+        """Return a copy ("clone") of the MAC object.
+
+        The copy will have the same internal state as the original MAC
+        object.
+        This can be used to efficiently compute the MAC of strings that
+        share a common initial substring.
+
+        :Returns: A `XCBCMAC` object
+        """
+        obj = XCBCMAC(self._key, ciphermod=self._factory)
+
+        _SmoothMAC._deep_copy(self, obj)
+
+        for m in [ '_tag', '_IV']:
+            setattr(obj, m, getattr(self, m))
+
+        return obj
+
+def new(key, msg=None, ciphermod=None):
+    """Create a new XCBCMAC object.
+
+    :Parameters:
+        key : byte string
+            secret key for the XCBCMAC object.
+            The key must be valid for the underlying cipher algorithm.
+            For instance, it must be 16 bytes long for AES-128.
+        msg : byte string
+            The very first chunk of the message to authenticate.
+            It is equivalent to an early call to `XCBCMAC.update`. Optional.
+        ciphermod : module
+            A cipher module from `Crypto.Cipher`.
+            The cipher's block size must be 64 or 128 bits.
+            Default is `Crypto.Cipher.AES`.
+
+    :Returns: A `XCBCMAC` object
+    """
+    return XCBCMAC(key, msg, ciphermod)

--- a/lib/Crypto/SelfTest/Hash/__init__.py
+++ b/lib/Crypto/SelfTest/Hash/__init__.py
@@ -30,6 +30,7 @@ def get_tests(config={}):
     tests = []
     from Crypto.SelfTest.Hash import test_HMAC;       tests += test_HMAC.get_tests(config=config)
     from Crypto.SelfTest.Hash import test_CMAC;       tests += test_CMAC.get_tests(config=config)
+    from Crypto.SelfTest.Hash import test_XCBCMAC;    tests += test_XCBCMAC.get_tests(config=config)
     from Crypto.SelfTest.Hash import test_MD2;        tests += test_MD2.get_tests(config=config)
     from Crypto.SelfTest.Hash import test_MD4;        tests += test_MD4.get_tests(config=config)
     from Crypto.SelfTest.Hash import test_MD5;        tests += test_MD5.get_tests(config=config)

--- a/lib/Crypto/SelfTest/Hash/test_XCBCMAC.py
+++ b/lib/Crypto/SelfTest/Hash/test_XCBCMAC.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+#
+#  SelfTest/Hash/test_XCBCMAC.py: Self-test for the XCBCMAC module
+#
+# ===================================================================
+# The contents of this file are dedicated to the public domain.  To
+# the extent that dedication to the public domain is not available,
+# everyone is granted a worldwide, perpetual, royalty-free,
+# non-exclusive license to exercise all rights associated with the
+# contents of this file for any purpose whatsoever.
+# No rights are reserved.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# ===================================================================
+
+"""Self-test suite for Crypto.Hash.XCBCMAC"""
+
+import sys
+if sys.version_info[0] == 2 and sys.version_info[1] == 1:
+    from Crypto.Util.py21compat import *
+from Crypto.Util.py3compat import *
+
+from common import dict
+
+from Crypto.Hash import XCBCMAC
+from Crypto.Cipher import AES
+
+# This is a list of (key, data, result, description, module) tuples.
+test_data = [
+    (
+        '000102030405060708090a0b0c0d0e0f',
+        '',
+        '75f0251d528ac01c4573dfd584d79f29',
+        'RFC 3566 #1',
+        AES
+    ),
+
+    (
+        '000102030405060708090a0b0c0d0e0f',
+        '000102',
+        '5b376580ae2f19afe7219ceef172756f',
+        'RFC 3566 #2',
+        AES
+    ),
+
+    (
+        '000102030405060708090a0b0c0d0e0f',
+        '000102030405060708090a0b0c0d0e0f',
+        'd2a246fa349b68a79998a4394ff7a263',
+        'RFC 3566 #3',
+        AES
+    ),
+
+    (
+        '000102030405060708090a0b0c0d0e0f',
+        '000102030405060708090a0b0c0d0e0f10111213',
+        '47f51b4564966215b8985c63055ed308',
+        'RFC 3566 #4',
+        AES
+    ),
+
+    (
+        '000102030405060708090a0b0c0d0e0f',
+        '000102030405060708090a0b0c0d0e0f10111213141516171819' +
+        '1a1b1c1d1e1f',
+        'f54f0ec8d2b9f3d36807734bd5283fd4',
+        'RFC 3566 #5',
+        AES
+    ),
+
+    (
+        '000102030405060708090a0b0c0d0e0f',
+        '000102030405060708090a0b0c0d0e0f10111213141516171819' +
+        '1a1b1c1d1e1f2021',
+        'becbb3bccdb518a30677d5481fb6b4d8',
+        'RFC 3566 #6',
+        AES
+    ),
+
+    (
+        '000102030405060708090a0b0c0d0e0f',
+        '00' * 1000,
+        'f0dafee895db30253761103b5d84528f',
+        'RFC 3566 #7',
+        AES
+    ),
+]
+
+def get_tests(config={}):
+    global test_data
+    from common import make_mac_tests
+
+    # Add new() parameters to the back of each test vector
+    params_test_data = []
+    for row in test_data:
+        t = list(row)
+        t[4] = dict(ciphermod=t[4])
+        params_test_data.append(t)
+
+    return make_mac_tests(XCBCMAC, "XCBCMAC", params_test_data)
+
+if __name__ == '__main__':
+    import unittest
+    suite = lambda: unittest.TestSuite(get_tests())
+    unittest.main(defaultTest='suite')


### PR DESCRIPTION
XCBC-MAC is often used in ipsec. The only difference with CMAC is the
way to compute subkeys (RFC 3566 section 4).

Since the algorithm is _very_ similar to CMAC I chose to put the class
in the same file. I simply added an optional `xcbc` parameter to the new()
function. If True, XCBCMAC will be used instead of CMAC.

The algorithm was checked against the test vectors provided in the RFC
(section 4.6).

See http://tools.ietf.org/html/rfc3566

Signed-off-by: Robin Jarry robin.jarry@6wind.com
