### PR TITLE
Fix speedtest run for ECB modes.

### DIFF
--- a/pct-speedtest.py
+++ b/pct-speedtest.py
@@ -186,6 +186,8 @@ class Benchmark:
                     initial_value=bytes_to_long(iv),
                     allow_wraparound=True)
             cipher = module.new(key, module.MODE_CTR, counter=ctr)
+        elif mode==module.MODE_ECB:
+            cipher = module.new(key, module.MODE_ECB)
         else:
             cipher = module.new(key, mode, iv)
 


### PR DESCRIPTION
Previously speedtest would fail for ECB modes because the IV argument was provided for DES.
