### PR TITLE
Increase attempts for recovering RSA (p,q) from (n,e,d)

### DIFF
--- a/lib/Crypto/PublicKey/_slowmath.py
+++ b/lib/Crypto/PublicKey/_slowmath.py
@@ -113,7 +113,7 @@ def rsa_construct(n, e, d=None, p=None, q=None, u=None):
         # as Factorization", M. Rabin, 1979
         spotted = 0
         a = 2
-        while not spotted and a<100:
+        while not spotted and a<1000:
             k = t
             # Cycle through all values a^{t*2^i}=a^k
             while k<ktot:

--- a/src/_fastmath.c
+++ b/src/_fastmath.c
@@ -606,7 +606,7 @@ static int factorize_N_from_D(rsaKey *key)
 	cnt = mpz_scan1(t, 0);
 	mpz_fdiv_q_2exp(t,t,cnt);
 	mpz_set_ui(a, 2);
-	for (spotted=0; (!spotted) && (mpz_cmp_ui(a,100)<0); mpz_add_ui(a,a,2)) {
+	for (spotted=0; (!spotted) && (mpz_cmp_ui(a,1000)<0); mpz_add_ui(a,a,2)) {
 		mpz_set(k, t);
 		for (; (mpz_cmp(k,ktot)<0); mpz_mul_ui(k,k,2)) {
 			mpz_powm(cand,a,k,key->n);


### PR DESCRIPTION
Bump the maximum number of iterations to recover (p,q) given (n,e,d) to
increase the chance that the algorithm succeeds. The algorithm used is a
probabilistic one with a 1/2 chance of finding the right value in each
iteration, so it's likely that only a few iterations are needed.

However, in some extreme cases this may still fail. Bumping the maximum
number allow the algorithm to correctly find the right values for these
cases. This changes bumps the number of iterations from 50 to 500 (the
value 'a' is increased by 2 in each step), and hence reduces the chance
of failure from 2**-50 to 2**-500.

Note that this change does _not_ result in a performance degradation.
