### PR TITLE
Allow zero-length strings for xor_strings() and xor_strings_with_char()

### DIFF
--- a/src/strxor.c
+++ b/src/strxor.c
@@ -41,9 +41,9 @@ xor_strings(char *dest, const char *src_a, const char *src_b, size_t n)
     size_t i;
 
     /* assert no pointer overflow */
-    assert(src_a + n > src_a);
-    assert(src_b + n > src_b);
-    assert(dest + n > dest);
+    assert(src_a + n >= src_a);
+    assert(src_b + n >= src_b);
+    assert(dest + n >= dest);
 
     for (i = 0; i < n; i++) {
         dest[i] = src_a[i] ^ src_b[i];
@@ -62,8 +62,8 @@ xor_string_with_char(char *dest, const char *src, char c, size_t n)
     size_t i;
 
     /* assert no pointer overflow */
-    assert(src + n > src);
-    assert(dest + n > dest);
+    assert(src + n >= src);
+    assert(dest + n >= dest);
 
     for (i = 0; i < n; i++) {
         dest[i] = src[i] ^ c;


### PR DESCRIPTION
Without this patch, something like "strxor('', '')" will trip the assertions. I'm guessing this isn't intended behavior -- if so, it should probably throw an exception instead.

Also worth pointing out that this code is checking for pointer overflows incorrectly -- see http://lwn.net/Articles/278137/ . But since these are (debug) assertions, it might not be such a big deal.

Although is it intended that these are on in release mode?
