### PR TITLE
Fix test for attribute HAVE_DECL_MPZ_POWM_SEC

### DIFF
--- a/lib/Crypto/Util/number.py
+++ b/lib/Crypto/Util/number.py
@@ -53,7 +53,7 @@ except ImportError:
     _fastmath = None
 
 # You need libgmp v5 or later to get mpz_powm_sec.  Warn if it's not available.
-if _fastmath is not None and not _fastmath.HAVE_DECL_MPZ_POWM_SEC:
+if _fastmath is not None and not hasattr(_fastmath, 'HAVE_DECL_MPZ_POWM_SEC'):
     _warn("Not using mpz_powm_sec.  You should rebuild using libgmp >= 5 to avoid timing attack vulnerability.", PowmInsecureWarning)
 
 # New functions


### PR DESCRIPTION
Existing test raises AttributeError (and traceback) in absence of
attribute. Use hasattr(obj, attr) rather than wrapping in try-except
block, since this is a test and not a genuine attempt to use.
