### PR TITLE
docs: fix simple typo, inlcude -> include

### DIFF
--- a/src/libtom/tomcrypt_cfg.h
+++ b/src/libtom/tomcrypt_cfg.h
@@ -1,6 +1,6 @@
 /* This is the build config file.
  *
- * With this you can setup what to inlcude/exclude automatically during any build.  Just comment
+ * With this you can setup what to include/exclude automatically during any build.  Just comment
  * out the line that #define's the word for the thing you want to remove.  phew!
  */
 


### PR DESCRIPTION
There is a small typo in src/libtom/tomcrypt_cfg.h.

Should read `include` rather than `inlcude`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md