### PR TITLE
Fix vacuous comparison in hash_SHA2_template.c

### DIFF
--- a/src/hash_SHA2_template.c
+++ b/src/hash_SHA2_template.c
@@ -93,7 +93,7 @@ static int add_length(hash_state *hs, sha2_word_t inc) {
     if (overflow_detector > hs->length_lower) {
         overflow_detector = hs->length_upper;
         hs->length_upper++;
-        if (hs->length_upper > hs->length_upper)
+        if (overflow_detector > hs->length_upper)
             return 0;
     }
     return 1;


### PR DESCRIPTION
L96 had a comparison that always returned false, instead of returning true when an overflow occurred.